### PR TITLE
fix bundler version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y curl build-essential git sqlite3 libsql
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && apt-get install -y nodejs git
 RUN npm install --global yarn
 
-RUN gem install bundler
+RUN gem install bundler -v 2.4.7
 COPY Gemfile* /myapp/
 RUN bundle install
 


### PR DESCRIPTION
bundle installに失敗するためバージョンを指定

```
 => [web  7/10] COPY Gemfile* /myapp/                                                                                                                                                                                                                       0.0s 
 => ERROR [web  8/10] RUN bundle install                                                                                                                                                                                                                    3.1s 
------                                                                                                                                                                                                                                                           
 > [web  8/10] RUN bundle install:                                                                                                                                                                                                                               
0.391 Bundler 2.5.9 is running, but your lockfile was generated with 2.4.7. Installing Bundler 2.4.7 and restarting using that version.                                                                                                                          
2.456 Fetching gem metadata from https://rubygems.org/.                                                                                                                                                                                                          
2.520 Fetching bundler 2.4.7                                                                                                                                                                                                                                     
2.675 Installing bundler 2.4.7
3.069 Your Ruby version is 3.2.2, but your Gemfile specified 3.2.1
------
```