### PR TITLE
fix singular fixture_path deprecation warning

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,9 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = Rails.root.join('spec/fixtures')
+  config.fixture_paths = [
+    Rails.root.join('spec/fixtures')
+  ]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
参考

[rails7.2から\`TestFixtures#fixture\_path\`が廃止されるためrails 7.1では\`DEPRECATION WARNING: TestFixtures#fixture\_path is deprecated\`が発生する #Ruby - Qiita](https://qiita.com/SoarTec-lab/items/933bc893cdf56b29d21a)