### PR TITLE
add setting for vscode-neovim version up

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,10 @@
     "editor.insertSpaces": true, // Use spaces and not tabs for indentantion
     "editor.semanticHighlighting.enabled": true, // Enable semantic highlighting
     "editor.formatOnType": true // Enable formatting while typing
+  },
+  "vscode-neovim.compositeKeys": {
+    "jj": {
+      "command": "vscode-neovim.escape"
+    }
   }
 }


### PR DESCRIPTION
- https://github.com/vscode-neovim/vscode-neovim?tab=readme-ov-file#migrate-from-the-compositeescape-command

shortcutの指定方法がバージョンアップにより変更になったので修正